### PR TITLE
CircleDrawerSlice to use command patterns for undo/redo history

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "postcss-import": "^16.1.0",
         "prettier": "^3.3.3",
         "prettier-plugin-tailwindcss": "^0.6.6",
+        "resize-observer-polyfill": "^1.5.1",
         "tailwindcss": "^3.4.10",
         "typescript": "^5.5.4",
         "typescript-eslint": "^8.0.1",
@@ -9393,6 +9394,12 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="
     },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "dev": true
+    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -17295,6 +17302,12 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="
+    },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "dev": true
     },
     "resolve": {
       "version": "1.22.8",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "postcss-import": "^16.1.0",
     "prettier": "^3.3.3",
     "prettier-plugin-tailwindcss": "^0.6.6",
+    "resize-observer-polyfill": "^1.5.1",
     "tailwindcss": "^3.4.10",
     "typescript": "^5.5.4",
     "typescript-eslint": "^8.0.1",

--- a/src/components/guis/CircleDrawer.test.tsx
+++ b/src/components/guis/CircleDrawer.test.tsx
@@ -1,0 +1,88 @@
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '~/test-utils'
+
+import CircleDrawer from './CircleDrawer'
+
+describe('CircleDrawer', () => {
+  test('adding circles to circle drawer', async () => {
+    const { user } = renderWithProviders(<CircleDrawer />)
+    // expects both empty undo and redo
+    expect(screen.getByRole('button', { name: /undo/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /redo/i })).toBeDisabled()
+    const canvas = screen.getByTestId('Circle Drawer')
+    expect(canvas.querySelectorAll('circle').length).toBe(0)
+
+    // pressing 2 circles, expect 2 circles and undo not disabled, redo disabled
+    await user.pointer({ target: canvas, coords: { x: 200, y: 50 } })
+    await user.click(canvas)
+
+    await user.pointer({ target: canvas, coords: { x: 300, y: 100 } })
+    await user.click(canvas)
+
+    expect(canvas.querySelectorAll('circle').length).toBe(2)
+    expect(screen.getByRole('button', { name: /undo/i })).toBeEnabled()
+    expect(screen.getByRole('button', { name: /redo/i })).toBeDisabled()
+
+    // press undo, there should be one circle, undo not disabled, and redo not disabled
+    await user.click(screen.getByRole('button', { name: /undo/i }))
+    expect(canvas.querySelectorAll('circle').length).toBe(1)
+    expect(screen.getByRole('button', { name: /undo/i })).toBeEnabled()
+    expect(screen.getByRole('button', { name: /redo/i })).toBeEnabled()
+
+    // press undo again, no circles, undo disabled, redo not disabled
+    await user.click(screen.getByRole('button', { name: /undo/i }))
+    expect(canvas.querySelectorAll('circle').length).toBe(0)
+    expect(screen.getByRole('button', { name: /undo/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /redo/i })).toBeEnabled()
+  })
+
+  // resource: https://github.com/adevinta/spark/blob/main/packages/components/slider/src/Slider.test.tsx
+  test('adjust diamter of circle', async () => {
+    const { user } = renderWithProviders(<CircleDrawer />)
+    // expects both empty undo and redo
+    expect(screen.getByRole('button', { name: /undo/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /redo/i })).toBeDisabled()
+    const canvas = screen.getByTestId('Circle Drawer')
+    expect(canvas.querySelectorAll('circle').length).toBe(0)
+
+    // add a circle
+    await user.pointer({ target: canvas, coords: { x: 200, y: 50 } })
+    await user.click(canvas)
+
+    expect(canvas.querySelectorAll('circle').length).toBe(1)
+    expect(screen.getByRole('button', { name: /undo/i })).toBeEnabled()
+    expect(screen.getByRole('button', { name: /redo/i })).toBeDisabled()
+    const circle = canvas.querySelector('circle')
+    expect(circle).toHaveAttribute('r', expect.stringMatching('20'))
+
+    // adjust circle diameter,
+    await user.click(circle!)
+    const slider = screen.getByRole('slider')
+    expect(slider).toHaveAttribute('aria-valuenow', expect.stringMatching('20'))
+
+    // had to use keyboard interactions to change sliders, instead of dragging slider, helps with accessibility
+    // Shift + ArrowUp, increases value by a larger step, this time it is 30
+    // https://www.radix-ui.com/primitives/docs/components/slider#keyboard-interactions
+    await user.keyboard('{Shift>}{ArrowUp}')
+    expect(slider).toHaveAttribute('aria-valuenow', expect.stringMatching('30'))
+    expect(circle).toHaveAttribute('r', expect.stringMatching('30'))
+
+    // press undo, circle to be 20, redo to be not disabled, unto not disabled
+    await user.click(screen.getByRole('button', { name: /undo/i }))
+    expect(circle).toHaveAttribute('r', expect.stringMatching('20'))
+    expect(screen.getByRole('button', { name: /undo/i })).toBeEnabled()
+    expect(screen.getByRole('button', { name: /redo/i })).toBeEnabled()
+
+    // press redo, redo disabled undo not disabled, circle back to 30,
+    await user.click(screen.getByRole('button', { name: /redo/i }))
+    expect(circle).toHaveAttribute('r', expect.stringMatching('30'))
+    expect(screen.getByRole('button', { name: /undo/i })).toBeEnabled()
+    expect(screen.getByRole('button', { name: /redo/i })).toBeDisabled()
+
+    // press undo twice, undo disabled, redo not disabled, no more circles
+    await user.dblClick(screen.getByRole('button', { name: /undo/i }))
+    expect(canvas.querySelectorAll('circle').length).toBe(0)
+    expect(screen.getByRole('button', { name: /undo/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /redo/i })).toBeEnabled()
+  })
+})

--- a/src/components/guis/CircleDrawer.tsx
+++ b/src/components/guis/CircleDrawer.tsx
@@ -105,6 +105,7 @@ export default function CircleDrawer() {
 
       <svg
         className="h-60 w-full rounded-[var(--radius-4)] border border-solid border-[var(--gray-a9)]"
+        data-testid="Circle Drawer"
         onClick={(event) => {
           const { x, y } = event.currentTarget.getBoundingClientRect()
           const circle = {

--- a/src/components/guis/CircleDrawer.tsx
+++ b/src/components/guis/CircleDrawer.tsx
@@ -105,6 +105,7 @@ export default function CircleDrawer() {
 
       <svg
         className="h-60 w-full rounded-[var(--radius-4)] border border-solid border-[var(--gray-a9)]"
+        // Using data-testid. https://github.com/testing-library/dom-testing-library/issues/1295
         data-testid="Circle Drawer"
         onClick={(event) => {
           const { x, y } = event.currentTarget.getBoundingClientRect()

--- a/src/components/guis/CircleDrawer.tsx
+++ b/src/components/guis/CircleDrawer.tsx
@@ -83,7 +83,6 @@ const Circle = memo(
     )
   },
   (prevProps, nextProps) => {
-    console.log(nextProps, nextProps)
     // only rerender selected/deselected circle
     if (prevProps.isSelected !== nextProps.isSelected) {
       return false

--- a/src/state/circleDrawerSlice.ts
+++ b/src/state/circleDrawerSlice.ts
@@ -33,12 +33,9 @@ interface CircleUpdateAction {
 
 type CircleAction = CircleAddAction | CircleDeleteAction | CircleUpdateAction
 
-// This implementation uses snapshots of circles with each action
-// Ideally implementation should use a stack of actions (command pattern) because it is more memory efficient
-
 interface CircleDrawerState {
   circles: EntityMap<Circle>
-  // undos and redos is a stack of circles snapshot
+  // undos and redos is a stack of circles actions, when popped does the CircleAction
   undos: CircleAction[]
   redos: CircleAction[]
   ui: {

--- a/src/state/circleDrawerSlice.ts
+++ b/src/state/circleDrawerSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice, current, nanoid } from '@reduxjs/toolkit'
+import { createSlice, nanoid } from '@reduxjs/toolkit'
 import type { PayloadAction } from '@reduxjs/toolkit'
 
 import type { EntityMap } from './types'
@@ -10,14 +10,37 @@ interface Circle {
   radius: number
 }
 
+interface CircleAddAction {
+  type: 'add'
+  id: string
+  x: number
+  y: number
+  radius: number
+}
+
+interface CircleDeleteAction {
+  type: 'delete'
+  id: string
+}
+
+interface CircleUpdateAction {
+  type: 'update'
+  id: string
+  x: number
+  y: number
+  radius: number
+}
+
+type CircleAction = CircleAddAction | CircleDeleteAction | CircleUpdateAction
+
 // This implementation uses snapshots of circles with each action
 // Ideally implementation should use a stack of actions (command pattern) because it is more memory efficient
 
 interface CircleDrawerState {
   circles: EntityMap<Circle>
   // undos and redos is a stack of circles snapshot
-  undos: EntityMap<Circle>[]
-  redos: EntityMap<Circle>[]
+  undos: CircleAction[]
+  redos: CircleAction[]
   ui: {
     selectedCircleId: string
     selectedCircleRadius: number
@@ -44,16 +67,15 @@ const circleDrawerSlice = createSlice({
     circleAdded: {
       reducer: (state, action: PayloadAction<Circle>) => {
         const newCircle = action.payload
-        // push current snapshot to undo
-        const currentCirclesSnapshot = current(state.circles)
-        state.undos.push(currentCirclesSnapshot)
-
-        // new circles snapshot
+        // add new circle
         state.circles.byId[newCircle.id] = newCircle
         state.circles.allIds.push(newCircle.id)
 
+        // when undo happens, delete that circle
+        state.undos.push({ type: 'delete', id: newCircle.id })
         // clear redos
         state.redos = []
+
         state.ui.selectedCircleId = ''
       },
       prepare: (circleProps: Omit<Circle, 'id'>) => {
@@ -68,18 +90,19 @@ const circleDrawerSlice = createSlice({
     circleUpdated: (state, action: PayloadAction<Circle>) => {
       const circle = action.payload
       const { x: newX, y: newY, radius: newRadius } = circle
-      if (!state.circles.byId[circle.id]) return
+      const circleToUpdate = state.circles.byId[circle.id]
+      // make sure circle exists, and there are changes to the circle
+      if (!circleToUpdate) return
 
       if (
-        state.circles.byId[circle.id].radius === newRadius &&
-        state.circles.byId[circle.id].x === newX &&
-        state.circles.byId[circle.id].y === newY
+        circleToUpdate.radius === newRadius &&
+        circleToUpdate.x === newX &&
+        circleToUpdate.y === newY
       )
         return
 
-      // push current snapshot to undo
-      const currentCirclesSnapshot = current(state.circles)
-      state.undos.push(currentCirclesSnapshot)
+      // when undo happens, go back to the old circle state
+      state.undos.push({ type: 'update', ...circleToUpdate })
 
       // updates circle
       state.circles.byId[circle.id] = circle
@@ -89,26 +112,116 @@ const circleDrawerSlice = createSlice({
     },
     undo: (state) => {
       if (state.undos.length > 0) {
-        // push current snapshot to redo
-        const currentCirclesSnapshot = current(state.circles)
-        state.redos.push(currentCirclesSnapshot)
+        // pop and do that action
+        const circleAction = state.undos.pop()!
+        const circleId = circleAction.id
 
-        // revert to previous circle snapshot from undo
-        const previousCirclesSnapshot = state.undos.pop()
-        state.circles = previousCirclesSnapshot!
+        switch (circleAction.type) {
+          case 'add': {
+            // add delete to redo
+            state.redos.push({ type: 'delete', id: circleId })
+
+            // add new circle
+            state.circles.allIds.push(circleId)
+            state.circles.byId[circleId] = {
+              id: circleId,
+              x: circleAction.x,
+              y: circleAction.y,
+              radius: circleAction.radius,
+            }
+
+            break
+          }
+          case 'update': {
+            // add update to redo
+            const circleToUpdate = state.circles.byId[circleId]
+            state.redos.push({ type: 'update', ...circleToUpdate })
+
+            // update circle
+            state.circles.byId[circleId] = {
+              id: circleId,
+              x: circleAction.x,
+              y: circleAction.y,
+              radius: circleAction.radius,
+            }
+
+            break
+          }
+          case 'delete': {
+            // add to redo
+            const circleToDelete = state.circles.byId[circleId]
+            state.redos.push({ type: 'add', ...circleToDelete })
+
+            // delete circle
+            delete state.circles.byId[circleId]
+            const index = state.circles.allIds.findIndex(
+              (id) => id === circleId,
+            )
+            if (index !== -1) state.circles.allIds.splice(index, 1)
+
+            break
+          }
+          default:
+            break
+        }
 
         state.ui.selectedCircleId = ''
       }
     },
     redo: (state) => {
       if (state.redos.length > 0) {
-        // push current snapshot to undo
-        const currentCirclesSnapshot = current(state.circles)
-        state.undos.push(currentCirclesSnapshot)
+        // pop and do that action
+        const circleAction = state.redos.pop()!
+        const circleId = circleAction.id
 
-        // pop from redo snapshot
-        const previousCirclesSnapshot = state.redos.pop()
-        state.circles = previousCirclesSnapshot!
+        switch (circleAction.type) {
+          case 'add': {
+            // add delete to undo
+            state.undos.push({ type: 'delete', id: circleId })
+
+            // add new circle
+            state.circles.allIds.push(circleId)
+            state.circles.byId[circleId] = {
+              id: circleId,
+              x: circleAction.x,
+              y: circleAction.y,
+              radius: circleAction.radius,
+            }
+
+            break
+          }
+          case 'update': {
+            // add update to undo
+            const circleToUpdate = state.circles.byId[circleId]
+            state.undos.push({ type: 'update', ...circleToUpdate })
+
+            // update circle
+            state.circles.byId[circleId] = {
+              id: circleId,
+              x: circleAction.x,
+              y: circleAction.y,
+              radius: circleAction.radius,
+            }
+
+            break
+          }
+          case 'delete': {
+            // add to undo
+            const circleToDelete = state.circles.byId[circleId]
+            state.undos.push({ type: 'add', ...circleToDelete })
+
+            // delete circle
+            delete state.circles.byId[circleId]
+            const index = state.circles.allIds.findIndex(
+              (id) => id === circleId,
+            )
+            if (index !== -1) state.circles.allIds.splice(index, 1)
+
+            break
+          }
+          default:
+            break
+        }
 
         state.ui.selectedCircleId = ''
       }

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -2,4 +2,5 @@ import '@testing-library/jest-dom/vitest'
 
 import ResizeObserver from 'resize-observer-polyfill'
 
+// @ts-expect-error https://stackoverflow.com/a/67006794
 global.ResizeObserver = ResizeObserver

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,8 +1,5 @@
 import '@testing-library/jest-dom/vitest'
 
-import { cleanup } from '@testing-library/react'
-import { afterEach } from 'vitest'
+import ResizeObserver from 'resize-observer-polyfill'
 
-afterEach(() => {
-  cleanup()
-})
+global.ResizeObserver = ResizeObserver


### PR DESCRIPTION
Changes pattern to undo/redo stack of circle actions instead of storing snapshots on undo/redo stack. This change makes the slice use way less memory when there are a lots of circle changes in the application.